### PR TITLE
refactor: Removing scalar generic types, will always use f32 since am…

### DIFF
--- a/examples/boxes/bundle.rs
+++ b/examples/boxes/bundle.rs
@@ -2,14 +2,13 @@ use std::fmt::Debug;
 use std::marker;
 
 use amethyst::core::{ECSBundle, Result};
-use amethyst::core::cgmath::{Array, BaseFloat, EuclideanSpace, InnerSpace, Quaternion, Rotation,
+use amethyst::core::cgmath::{Array, EuclideanSpace, InnerSpace, Quaternion, Rotation,
                              Vector3, Zero};
 use amethyst::ecs::{DispatcherBuilder, Entity, World};
 use amethyst::shrev::EventChannel;
 use amethyst_rhusics::Convert;
 use collision::{Bound, ComputeBound, Primitive, Union};
 use rand::Rand;
-use rand::distributions::range::SampleRange;
 use rhusics_core::{ContactEvent, Inertia};
 
 use super::{BoxDeletionSystem, EmissionSystem, Emitter, ObjectType};
@@ -43,9 +42,8 @@ impl<'a, 'b, P, B, R, A, I> ECSBundle<'a, 'b> for BoxSimulationBundle<P, B, R, A
 where
     B: Bound<Point = P::Point> + Union<B, Output = B> + Clone + Send + Sync + 'static,
     P: Primitive + ComputeBound<B> + Clone + Send + Sync + 'static,
-    P::Point: EuclideanSpace + Convert<Output = Vector3<f32>> + Debug + Send + Sync + 'static,
+    P::Point: EuclideanSpace<Scalar = f32> + Convert<Output = Vector3<f32>> + Debug + Send + Sync + 'static,
     <P::Point as EuclideanSpace>::Diff: Debug + Rand + InnerSpace + Array + Send + Sync + 'static,
-    <P::Point as EuclideanSpace>::Scalar: BaseFloat + Rand + SampleRange + Send + Sync + 'static,
     R: Rotation<P::Point> + Convert<Output = Quaternion<f32>> + Send + Sync + 'static,
     A: Clone + Copy + Zero + Send + Sync + 'static,
     I: Inertia + Send + Sync + 'static,

--- a/examples/boxes/default.rs
+++ b/examples/boxes/default.rs
@@ -5,18 +5,11 @@ use collision::primitive::{Primitive2, Primitive3};
 use super::bundle::BoxSimulationBundle;
 
 /// Box simulation for 2D
-///
-/// ### Type parameters
-///
-/// - `S`: Scalar (`f32` or `f64`)
 #[allow(dead_code)]
-pub type BoxSimulationBundle2<S> = BoxSimulationBundle<Primitive2<S>, Aabb2<S>, Basis2<S>, S, S>;
+pub type BoxSimulationBundle2 =
+    BoxSimulationBundle<Primitive2<f32>, Aabb2<f32>, Basis2<f32>, f32, f32>;
 
 /// Box simulation for 2D
-///
-/// ### Type parameters
-///
-/// - `S`: Scalar (`f32` or `f64`)
 #[allow(dead_code)]
-pub type BoxSimulationBundle3<S> =
-    BoxSimulationBundle<Primitive3<S>, Aabb3<S>, Quaternion<S>, Vector3<S>, Matrix3<S>>;
+pub type BoxSimulationBundle3 =
+    BoxSimulationBundle<Primitive3<f32>, Aabb3<f32>, Quaternion<f32>, Vector3<f32>, Matrix3<f32>>;

--- a/examples/boxes/deletion.rs
+++ b/examples/boxes/deletion.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use amethyst::core::cgmath::{BaseFloat, EuclideanSpace};
+use amethyst::core::cgmath::EuclideanSpace;
 use amethyst::ecs::{Entities, Entity, Fetch, ReadStorage, System};
 use amethyst::shrev::{EventChannel, ReaderId};
 use rhusics_core::ContactEvent;
@@ -14,18 +14,16 @@ use super::ObjectType;
 /// - `P`: Positional quantity (`Point2` or `Point3`)
 pub struct BoxDeletionSystem<P>
 where
-    P: EuclideanSpace,
+    P: EuclideanSpace<Scalar = f32>,
     P::Diff: Debug,
-    P::Scalar: BaseFloat,
 {
     contact_reader: ReaderId<ContactEvent<Entity, P>>,
 }
 
 impl<P> BoxDeletionSystem<P>
 where
-    P: EuclideanSpace,
+    P: EuclideanSpace<Scalar = f32>,
     P::Diff: Debug,
-    P::Scalar: BaseFloat,
 {
     pub fn new(contact_reader: ReaderId<ContactEvent<Entity, P>>) -> Self {
         Self { contact_reader }
@@ -34,9 +32,8 @@ where
 
 impl<'a, P> System<'a> for BoxDeletionSystem<P>
 where
-    P: EuclideanSpace + Debug + Send + Sync + 'static,
+    P: EuclideanSpace<Scalar = f32> + Debug + Send + Sync + 'static,
     P::Diff: Debug + Send + Sync + 'static,
-    P::Scalar: BaseFloat + Send + Sync + 'static,
 {
     type SystemData = (
         Entities<'a>,

--- a/examples/boxes2d.rs
+++ b/examples/boxes2d.rs
@@ -271,8 +271,8 @@ fn run() -> Result<(), amethyst::Error> {
 
     let mut game = Application::build("./", Emitting)?
         .with_bundle(FPSCounterBundle::default())?
-        .with_bundle(DefaultBasicPhysicsBundle2::<f32, ObjectType>::new())?
-        .with_bundle(BoxSimulationBundle2::<f32>::new(
+        .with_bundle(DefaultBasicPhysicsBundle2::<ObjectType>::new())?
+        .with_bundle(BoxSimulationBundle2::new(
             Rectangle::new(0.1, 0.1).into(),
         ))?
         .with_bundle(TransformBundle::new().with_dep(&["sync_system"]))?

--- a/src/default.rs
+++ b/src/default.rs
@@ -1,32 +1,28 @@
 use amethyst_core::cgmath::{Basis2, Point2, Point3, Quaternion};
 use collision::{Aabb2, Aabb3};
-use collision::dbvt::TreeValueWrapped;
 use collision::primitive::{Primitive2, Primitive3};
-use specs::Entity;
 
 use bundle::{BasicPhysicsBundle2, BasicPhysicsBundle3};
 use system::PoseTransformSyncSystem;
 
 /// Utility type for a 2D sync system (from `BodyPose` to `Transform`).
-pub type PoseTransformSyncSystem2<S> = PoseTransformSyncSystem<Point2<S>, Basis2<S>>;
+pub type PoseTransformSyncSystem2 = PoseTransformSyncSystem<Point2<f32>, Basis2<f32>>;
 
 /// Utility type for a 3D sync system (from `BodyPose` to `Transform`).
-pub type PoseTransformSyncSystem3<S> = PoseTransformSyncSystem<Point3<S>, Quaternion<S>>;
+pub type PoseTransformSyncSystem3 = PoseTransformSyncSystem<Point3<f32>, Quaternion<f32>>;
 
 /// Utility type for a default 2D physics setup (including collision detection).
 ///
 /// ### Type parameters:
 ///
-/// - `S`: scalar type (`f32` or `f64`)
 /// - `Y`: collision detection manager type (see `rhusics_core::Collider` for more information)
-pub type DefaultBasicPhysicsBundle2<S, Y> =
-    BasicPhysicsBundle2<S, Primitive2<S>, Aabb2<S>, TreeValueWrapped<Entity, Aabb2<S>>, Y>;
+pub type DefaultBasicPhysicsBundle2<Y> =
+    BasicPhysicsBundle2<Primitive2<f32>, Aabb2<f32>, Y>;
 
 /// Utility type for a default 3D physics setup (including collision detection).
 ///
 /// ### Type parameters:
 ///
-/// - `S`: scalar type (`f32` or `f64`)
 /// - `Y`: collision detection manager type (see `rhusics_core::Collider` for more information)
-pub type DefaultBasicPhysicsBundle3<S, Y> =
-    BasicPhysicsBundle3<S, Primitive3<S>, Aabb3<S>, TreeValueWrapped<Entity, Aabb3<S>>, Y>;
+pub type DefaultBasicPhysicsBundle3<Y> =
+    BasicPhysicsBundle3<Primitive3<f32>, Aabb3<f32>, Y>;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,5 @@
 use amethyst_core::Transform;
-use amethyst_core::cgmath::{Array, BaseFloat, Basis2, EuclideanSpace, Matrix3, Point2, Point3,
+use amethyst_core::cgmath::{Array, Basis2, EuclideanSpace, Matrix3, Point2, Point3,
                             Quaternion, Rotation, Vector3};
 use amethyst_core::timing::Time;
 use rhusics_core::BodyPose;
@@ -23,45 +23,32 @@ pub trait Convert {
     fn convert(&self) -> Self::Output;
 }
 
-impl<S> Convert for Point2<S>
-where
-    S: BaseFloat,
-{
+impl Convert for Point2<f32> {
     type Output = Vector3<f32>;
 
     fn convert(&self) -> Self::Output {
-        Vector3::new(self.x.to_f32().unwrap(), self.y.to_f32().unwrap(), 0.)
+        Vector3::new(self.x, self.y, 0.)
     }
 }
 
-impl<S> Convert for Point3<S>
-where
-    S: BaseFloat,
-{
+impl Convert for Point3<f32> {
     type Output = Vector3<f32>;
 
     fn convert(&self) -> Self::Output {
-        Vector3::new(
-            self.x.to_f32().unwrap(),
-            self.y.to_f32().unwrap(),
-            self.z.to_f32().unwrap(),
-        )
+        self.to_vec()
     }
 }
 
-impl<S> Convert for Basis2<S>
-where
-    S: BaseFloat,
-{
+impl Convert for Basis2<f32> {
     type Output = Quaternion<f32>;
 
     fn convert(&self) -> Self::Output {
         Matrix3::new(
-            self.as_ref()[0][0].to_f32().unwrap(),
-            self.as_ref()[0][1].to_f32().unwrap(),
+            self.as_ref()[0][0],
+            self.as_ref()[0][1],
             0.,
-            self.as_ref()[1][0].to_f32().unwrap(),
-            self.as_ref()[1][1].to_f32().unwrap(),
+            self.as_ref()[1][0],
+            self.as_ref()[1][1],
             0.,
             0.,
             0.,
@@ -70,26 +57,17 @@ where
     }
 }
 
-impl<S> Convert for Quaternion<S>
-where
-    S: BaseFloat,
-{
+impl Convert for Quaternion<f32> {
     type Output = Quaternion<f32>;
 
     fn convert(&self) -> Self::Output {
-        Quaternion::new(
-            self.s.to_f32().unwrap(),
-            self.v.x.to_f32().unwrap(),
-            self.v.y.to_f32().unwrap(),
-            self.v.z.to_f32().unwrap(),
-        )
+        *self
     }
 }
 
 impl<P, R> AsTransform for BodyPose<P, R>
 where
-    P: EuclideanSpace + Convert<Output = Vector3<f32>>,
-    P::Scalar: BaseFloat,
+    P: EuclideanSpace<Scalar = f32> + Convert<Output = Vector3<f32>>,
     R: Rotation<P> + Convert<Output = Quaternion<f32>>,
 {
     fn as_transform(&self) -> Transform {

--- a/src/system/sync.rs
+++ b/src/system/sync.rs
@@ -1,7 +1,7 @@
 use std::marker;
 
 use amethyst_core::Transform;
-use amethyst_core::cgmath::{BaseFloat, EuclideanSpace, Quaternion, Rotation, Vector3};
+use amethyst_core::cgmath::{EuclideanSpace, Quaternion, Rotation, Vector3};
 use rhusics_core::BodyPose;
 use specs::{Join, ReadStorage, System, WriteStorage};
 
@@ -12,8 +12,8 @@ use sync::Convert;
 ///
 /// ### Type parameters:
 ///
-/// - `P`: Positional quantity (`Point2` or `Point3` in most scenarios).
-/// - `R`: Rotational quantity (`Basis2` or `Quaternion` in most scenarios).
+/// - `P`: Positional quantity (`Point2<f32>` or `Point3<f32>` in most scenarios).
+/// - `R`: Rotational quantity (`Basis2<f32>` or `Quaternion<f32>` in most scenarios).
 pub struct PoseTransformSyncSystem<P, R> {
     m: marker::PhantomData<(P, R)>,
 }
@@ -29,9 +29,8 @@ impl<P, R> PoseTransformSyncSystem<P, R> {
 
 impl<'a, P, R> System<'a> for PoseTransformSyncSystem<P, R>
 where
-    P: EuclideanSpace + Convert<Output = Vector3<f32>> + Send + Sync + 'static,
+    P: EuclideanSpace<Scalar = f32> + Convert<Output = Vector3<f32>> + Send + Sync + 'static,
     R: Rotation<P> + Convert<Output = Quaternion<f32>> + Send + Sync + 'static,
-    P::Scalar: BaseFloat,
 {
     type SystemData = (ReadStorage<'a, BodyPose<P, R>>, WriteStorage<'a, Transform>);
 


### PR DESCRIPTION
…ethyst use that. Also forcing usage of TreeValueWrapped, since it's very unlikely people will choose a different implementation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst-rhusics/18)
<!-- Reviewable:end -->
