### PR TITLE
Fix wrong positionning in 2d arena creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst-rhusics"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 
 repository = "https://github.com/amethyst/amethyst-rhusics.git"

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -103,7 +103,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(center.x, min.y), Point2::new(center.x, max.y)).into(),
+                Line2::new(Point2::new(0.0, min.y), Point2::new(0.0, max.y)).into(),
                 types.0,
             ),
             BodyPose2::new(Point2::new(min.x, center.y), Basis2::one()),
@@ -117,7 +117,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(center.x, min.y), Point2::new(center.x, max.y)).into(),
+                Line2::new(Point2::new(0.0, min.y), Point2::new(0.0, max.y)).into(),
                 types.1,
             ),
             BodyPose2::new(Point2::new(max.x, center.y), Basis2::one()),
@@ -131,7 +131,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(min.x, center.y), Point2::new(max.x, center.y)).into(),
+                Line2::new(Point2::new(min.x, 0.0), Point2::new(max.x, 0.0)).into(),
                 types.2,
             ),
             BodyPose2::new(Point2::new(center.x, min.y), Basis2::one()),
@@ -145,7 +145,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(min.x, center.y), Point2::new(max.x, center.y)).into(),
+                Line2::new(Point2::new(min.x, 0.0), Point2::new(max.x, 0.0)).into(),
                 types.3,
             ),
             BodyPose2::new(Point2::new(center.x, max.y), Basis2::one()),

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -96,6 +96,7 @@ where
     Y: Default + Send + Sync + 'static,
 {
     type Shape2<Y> = CollisionShape<Primitive2<f32>, BodyPose2<f32>, Aabb2<f32>, Y>;
+    let dimensions = max - min;
     let center = (min + max.to_vec()) / 2.;
     world
         .create_entity()
@@ -103,7 +104,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(0.0, min.y), Point2::new(0.0, max.y)).into(),
+                Line2::new(Point2::new(0.0, -dimensions.y / 2.0), Point2::new(0.0, dimensions.y / 2.0)).into(),
                 types.0,
             ),
             BodyPose2::new(Point2::new(min.x, center.y), Basis2::one()),
@@ -117,7 +118,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(0.0, min.y), Point2::new(0.0, max.y)).into(),
+                Line2::new(Point2::new(0.0, -dimensions.y / 2.0), Point2::new(0.0, dimensions.y / 2.0)).into(),
                 types.1,
             ),
             BodyPose2::new(Point2::new(max.x, center.y), Basis2::one()),
@@ -131,7 +132,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(min.x, 0.0), Point2::new(max.x, 0.0)).into(),
+                Line2::new(Point2::new(-dimensions.x / 2.0, 0.0), Point2::new(dimensions.x / 2.0, 0.0)).into(),
                 types.2,
             ),
             BodyPose2::new(Point2::new(center.x, min.y), Basis2::one()),
@@ -145,7 +146,7 @@ where
             Shape2::new_simple_with_type(
                 CollisionStrategy::FullResolution,
                 CollisionMode::Discrete,
-                Line2::new(Point2::new(min.x, 0.0), Point2::new(max.x, 0.0)).into(),
+                Line2::new(Point2::new(-dimensions.x / 2.0, 0.0), Point2::new(dimensions.x / 2.0, 0.0)).into(),
                 types.3,
             ),
             BodyPose2::new(Point2::new(center.x, max.y), Basis2::one()),


### PR DESCRIPTION
The 2D arena were wrongly created: their collide lines were shifted from their BodyPos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst-rhusics/39)
<!-- Reviewable:end -->
